### PR TITLE
Add support for Google Inbox reply pattern

### DIFF
--- a/lib/email_reply_trimmer.rb
+++ b/lib/email_reply_trimmer.rb
@@ -33,7 +33,9 @@ class EmailReplyTrimmer
     text.gsub!("\r\n", "\n")
 
     # fix embedded email markers that might span over multiple lines
-    EmbeddedEmailMatcher::ON_DATE_SOMEONE_WROTE_REGEXES.each do |r|
+    (EmbeddedEmailMatcher::ON_DATE_SOMEONE_WROTE_REGEXES +
+      EmbeddedEmailMatcher::SOMEONE_WROTE_ON_DATE_REGEXES
+    ).each do |r|
       text.gsub!(r) { |m| m.gsub(/\n[[:space:]>\-]*/, " ") }
     end
 

--- a/lib/email_reply_trimmer/embedded_email_matcher.rb
+++ b/lib/email_reply_trimmer/embedded_email_matcher.rb
@@ -58,6 +58,19 @@ class EmbeddedEmailMatcher
     /.+#{user}.+#{wrote}:/
   end
 
+  # Max Mustermann <try_discourse@discoursemail.com> schrieb am Fr., 28. Apr. 2017 um 11:53 Uhr:
+  SOMEONE_WROTE_ON_DATE_MARKERS = [
+    # English
+    "wrote on",
+    # German
+    "schrieb am",
+  ]
+
+  SOMEONE_WROTE_ON_DATE_REGEXES = SOMEONE_WROTE_ON_DATE_MARKERS.map do |wrote_on|
+    wrote_on.gsub!(/ +/, "[[:space:]]+") # the "wrote" part might span over multiple lines
+    /^.+#{wrote_on}.+[^:]+:/
+  end
+
   # 2016-03-03 17:21 GMT+01:00 Some One
   ISO_DATE_SOMEONE_REGEX = /^[[:blank:]>]*20\d\d-\d\d-\d\d \d\d:\d\d GMT\+\d\d:\d\d [\w[:blank:]]+$/
 
@@ -110,6 +123,7 @@ class EmbeddedEmailMatcher
     ON_DATE_WROTE_SOMEONE_REGEXES,
     DATE_SOMEONE_WROTE_REGEXES,
     DATE_SOMEONE_EMAIL_REGEX,
+    SOMEONE_WROTE_ON_DATE_REGEXES,
     ISO_DATE_SOMEONE_REGEX,
     SOMEONE_VIA_SOMETHING_WROTE_REGEXES,
     SOMEONE_EMAIL_WROTE_REGEX,

--- a/test/elided/embedded_email_german_4.txt
+++ b/test/elided/embedded_email_german_4.txt
@@ -1,0 +1,15 @@
+Max Mustermann <try_discourse@discoursemail.com> schrieb am Fr., 28. Apr. 2017 um 11:53 Uhr:
+
+> max_2 <http://try.discourse.org/u/cfstras_2>
+> April 28
+
+> Hi there! you should be getting a mail.
+> ------------------------------
+
+> Visit Topic <http://try.discourse.org/t/this-is-my-internal-test/716/2>
+> or reply to this email to respond.
+
+> To unsubscribe from these emails, click here
+> <http://try.discourse.org/email/unsubscribe/badf00d>
+> .
+

--- a/test/emails/embedded_email_german_4.txt
+++ b/test/emails/embedded_email_german_4.txt
@@ -1,0 +1,18 @@
+
+Hi there! I am replying from my german Google Inbox.
+
+Max Mustermann <try_discourse@discoursemail.com> schrieb am Fr., 28.
+Apr. 2017 um 11:53 Uhr:
+
+> max_2 <http://try.discourse.org/u/cfstras_2>
+> April 28
+
+> Hi there! you should be getting a mail.
+> ------------------------------
+
+> Visit Topic <http://try.discourse.org/t/this-is-my-internal-test/716/2>
+> or reply to this email to respond.
+
+> To unsubscribe from these emails, click here
+> <http://try.discourse.org/email/unsubscribe/badf00d>
+> .

--- a/test/trimmed/embedded_email_german_4.txt
+++ b/test/trimmed/embedded_email_german_4.txt
@@ -1,0 +1,1 @@
+Hi there! I am replying from my german Google Inbox.


### PR DESCRIPTION
"<someone> wrote on <date>:", possibly multiline.
I also added an English variant, also I haven't seen that in the wild yet, so we might want to remove it. Can't really test with my Google Inbox either.

![image](https://cloud.githubusercontent.com/assets/1156864/25526926/397d39c6-2c16-11e7-821f-4456d7660cbb.png)

