### PR TITLE
Allowing delimiters inside of code blocks

### DIFF
--- a/lib/email_reply_trimmer/code_close_matcher.rb
+++ b/lib/email_reply_trimmer/code_close_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+=begin
+Code blocks must begin with three tick marks (```) on a line
+  Those tick marks may not have any characters before them
+  Openening tick marks may have text after them
+Code blocks must end with three tick marks (```) on a line
+  Those tick marks may have no more than three spaces before them
+  Those tick marks may only have white space after them
+=end
+
+class CodeCloseMatcher
+
+  DELIMITER_REGEX      ||= /^ {,3}```\s*$/
+
+  def self.match?(line)
+    line =~ DELIMITER_REGEX
+  end
+
+end

--- a/lib/email_reply_trimmer/code_open_matcher.rb
+++ b/lib/email_reply_trimmer/code_open_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+=begin
+Code blocks must begin with three tick marks (```) on a line
+  Those tick marks may not have any characters before them
+  Openening tick marks may have text after them
+Code blocks must end with three tick marks (```) on a line
+  Those tick marks may have no more than three spaces before them
+  Those tick marks may only have white space after them
+=end
+
+class CodeOpenMatcher
+
+  DELIMITER_REGEX      ||= /^```/
+
+  def self.match?(line)
+    line =~ DELIMITER_REGEX
+  end
+
+end

--- a/test/emails/block_code_spacers.txt
+++ b/test/emails/block_code_spacers.txt
@@ -1,0 +1,13 @@
+This is a long email with embedded code.
+
+```
+# This should not be deleted
+#
+
+# Or trimmed
+# It is code
+####
+Code code code
+```
+
+End of the email.

--- a/test/trimmed/block_code_spacers.txt
+++ b/test/trimmed/block_code_spacers.txt
@@ -1,0 +1,13 @@
+This is a long email with embedded code.
+
+```
+# This should not be deleted
+#
+
+# Or trimmed
+# It is code
+####
+Code code code
+```
+
+End of the email.


### PR DESCRIPTION
Addresses https://github.com/discourse/email_reply_trimmer/issues/21 and https://meta.discourse.org/t/email-trimming-improvement-no-trimming-in-code-blocks/320159

Adds two new regex classes identifying opening and closing code blocks based on Discourse rules for code blocks as I understand them.

Creates two new patterns for matching either of those code block patterns, and an additional pattern for matching both (since something like "```" will match both opening and closing block patterns).

Allows delimiters within code blocks.

Added a test case to show that it is indeed working as expected. No other test cases appear affected.