### PR TITLE
Alternate code block protection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
-def name
-  @name ||= Dir["*.gemspec"].first.split(".").first
-end
 
-def version
-  @version ||= File.read("lib/#{name}.rb")[/^\s*VERSION\s*=\s*['"](?'version'\d+\.\d+\.\d+)['"]/, "version"]
-end
+name = Dir["*.gemspec"].first.split(".").first
+version = File.read("lib/#{name}.rb")[/^\s*VERSION\s*=\s*['"](?'version'\d+\.\d+\.\d+)['"]/, "version"]
 
 task default: :test
 

--- a/lib/email_reply_trimmer/delimiter_matcher.rb
+++ b/lib/email_reply_trimmer/delimiter_matcher.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class DelimiterMatcher
 
-  DELIMITER_CHARACTERS ||= "-_,=+~#*ᐧ—"
-  DELIMITER_REGEX      ||= /^[[:blank:]]*[#{Regexp.escape(DELIMITER_CHARACTERS)}]+[[:blank:]]*$/
+  DELIMITER_CHARACTERS = "-_,=+~#*ᐧ—"
+  DELIMITER_REGEX      = /^[[:blank:]]*[#{Regexp.escape(DELIMITER_CHARACTERS)}]+[[:blank:]]*$/
 
   def self.match?(line)
     line =~ DELIMITER_REGEX

--- a/lib/email_reply_trimmer/email_header_matcher.rb
+++ b/lib/email_reply_trimmer/email_header_matcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class EmailHeaderMatcher
 
-  EMAIL_HEADERS_WITH_DATE_MARKERS ||= [
+  EMAIL_HEADERS_WITH_DATE_MARKERS = [
     # Norwegian
     ["Sendt"],
     # English
@@ -26,11 +26,11 @@ class EmailHeaderMatcher
     ["发送时间"],
   ]
 
-  EMAIL_HEADERS_WITH_DATE_REGEXES ||= EMAIL_HEADERS_WITH_DATE_MARKERS.map do |header|
+  EMAIL_HEADERS_WITH_DATE_REGEXES = EMAIL_HEADERS_WITH_DATE_MARKERS.map do |header|
     /^[[:blank:]*]*(?:#{header.join("|")})[[:blank:]*]*:.*\d+/
   end
 
-  EMAIL_HEADERS_WITH_TEXT_MARKERS ||= [
+  EMAIL_HEADERS_WITH_TEXT_MARKERS = [
     # Norwegian
     ["Fra", "Til", "Emne"],
     # English
@@ -53,11 +53,11 @@ class EmailHeaderMatcher
     ["发件人", "收件人", "主题"],
   ]
 
-  EMAIL_HEADERS_WITH_TEXT_REGEXES ||= EMAIL_HEADERS_WITH_TEXT_MARKERS.map do |header|
+  EMAIL_HEADERS_WITH_TEXT_REGEXES = EMAIL_HEADERS_WITH_TEXT_MARKERS.map do |header|
     /^[[:blank:]*]*(?:#{header.join("|")})[[:blank:]*]*:.*[[:word:]]+/i
   end
 
-  EMAIL_HEADER_REGEXES ||= [
+  EMAIL_HEADER_REGEXES = [
     EMAIL_HEADERS_WITH_DATE_REGEXES,
     EMAIL_HEADERS_WITH_TEXT_REGEXES,
   ].flatten

--- a/lib/email_reply_trimmer/embedded_email_matcher.rb
+++ b/lib/email_reply_trimmer/embedded_email_matcher.rb
@@ -12,7 +12,7 @@ class EmbeddedEmailMatcher
   # Em seg, 27 de jul de 2015 17:13, Neil Lalonde <info@discourse.org> escreveu:
   # El jueves, 21 de noviembre de 2013, codinghorror escribió:
   # At 6/16/2016 08:32 PM, you wrote:
-  ON_DATE_SOMEONE_WROTE_REGEXES ||= [
+  ON_DATE_SOMEONE_WROTE_REGEXES = [
     # Chinese
     /^[[:blank:]<>-]*在 (?:(?!\b(?>在|写道)\b).)+?写道[[:blank:].:>-]*$/im,
     # Dutch
@@ -73,7 +73,7 @@ class EmbeddedEmailMatcher
   end
 
   # Max Mustermann <try_discourse@discoursemail.com> schrieb am Fr., 28. Apr. 2017 um 11:53 Uhr:
-  SOMEONE_WROTE_ON_DATE_REGEXES ||= [
+  SOMEONE_WROTE_ON_DATE_REGEXES = [
     # English
     /^.+\bwrote\b[[:space:]]+\bon\b.+[^:]+:/,
     # German

--- a/lib/email_reply_trimmer/signature_matcher.rb
+++ b/lib/email_reply_trimmer/signature_matcher.rb
@@ -14,7 +14,7 @@ class SignatureMatcher
   # (sent from a phone)
   # (Sent from mobile device)
   # 從我的 iPhone 傳送
-  SIGNATURE_REGEXES ||= [
+  SIGNATURE_REGEXES = [
     # Chinese
     /^[[:blank:]]*從我的 iPhone 傳送/i,
     # English

--- a/test/emails/block_code_spacers.txt
+++ b/test/emails/block_code_spacers.txt
@@ -1,0 +1,13 @@
+This is a long email with embedded code.
+
+```
+# This should not be deleted
+#
+
+# Or trimmed
+# It is code
+####
+Code code code
+```
+
+End of the email.

--- a/test/trimmed/block_code_spacers.txt
+++ b/test/trimmed/block_code_spacers.txt
@@ -1,0 +1,13 @@
+This is a long email with embedded code.
+
+```
+# This should not be deleted
+#
+
+# Or trimmed
+# It is code
+####
+Code code code
+```
+
+End of the email.


### PR DESCRIPTION
Following further discussion at

https://meta.discourse.org/t/email-trimming-improvement-no-trimming-in-code-blocks/320159

Pulling code blocks out of the email to be trimmed completely, and then replacing them in a post-processing step. Added a test to demonstrate that this is working properly.

Thanks to zogstrip for the help!